### PR TITLE
bugfix: Добавил декоратор BrowserRouter в preview

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,4 +1,6 @@
 import '../src/index.css';
+import React from 'react';
+import { BrowserRouter } from 'react-router-dom';
 
 /** @type { import('@storybook/react').Preview } */
 import './../src/index.css';
@@ -12,6 +14,13 @@ const preview = {
 			},
 		},
 	},
+	decorators: [
+		(Story) => (
+			<BrowserRouter>
+				<Story />
+			</BrowserRouter>
+		),
+	],
 };
 
 export default preview;

--- a/src/components/pages/PageNotFound/PageNotFound.stories.js
+++ b/src/components/pages/PageNotFound/PageNotFound.stories.js
@@ -1,4 +1,3 @@
-import { BrowserRouter } from 'react-router-dom';
 import PageNotFound from './PageNotFound';
 
 export default {
@@ -9,8 +8,4 @@ export default {
 	},
 };
 
-export const Default = () => (
-	<BrowserRouter>
-		<PageNotFound />
-	</BrowserRouter>
-);
+export const Default = () => <PageNotFound />;


### PR DESCRIPTION
По комментарию ревьювера
Контексты лучше вынести в .storybook/preview.js там можно добавить декоратор. Напомню, что окружение в приложении и в сторибуке должно быть 100% идентичным, это ключевой фактор.